### PR TITLE
feat: introducing to -url and argv[1] param to test url from cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ build:
 	$(call deps_dirs)
 	go build -o bin/go-url *.go
 
+run:
+	go run *.go -url=http://www.google.com
+
 clean:
 	$(call deps_clean)
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,45 @@ Total time taken: 5251ms
 
 ``` 
 
+* read url from arg `-url`
+
+```bash
+$ ./bin/go-url -url https://www.google.com
+#> Reading config from Param
+#> Found [1] URLs to test, starting...
+URL=[                            https://www.google.com] [  OK] : [200 OK] [952 ms]
+Total time taken: 953ms
+
+$ ./bin/go-url -url https://www.google.com -dns
+#> Reading config from Param
+#> Found [1] URLs to test, starting...
+
+URL=[    (www.google.com) https://[2607:f8b0:4008:811::2004]:443/] [  OK] : [200 OK] [962 ms] [DNS 106 ms]
+URL=[              (www.google.com)   https://172.217.29.132:443/] [  OK] : [200 OK] [377 ms] [DNS 106 ms]
+Total time taken: 1446ms
+
+
+```
+
+
+* read url from arg `argv[1]`
+
+```bash
+$ ./bin/go-url https://www.google.com
+#> Reading config from Param
+#> Found [1] URLs to test, starting...
+URL=[                            https://www.google.com] [  OK] : [200 OK] [942 ms]
+Total time taken: 942ms
+
+$ ./bin/go-url -dns https://www.google.com
+#> Reading config from Param
+#> Found [1] URLs to test, starting...
+
+URL=[    (www.google.com) https://[2607:f8b0:4008:811::2004]:443/] [  OK] : [200 OK] [1870 ms] [DNS 113 ms]
+URL=[              (www.google.com)    https://172.217.30.68:443/] [  OK] : [200 OK] [236 ms] [DNS 113 ms]
+
+```
+
 ## Contributing
 
 <TODO>

--- a/config.go
+++ b/config.go
@@ -26,3 +26,9 @@ func configParserFromFile() {
 		os.Exit(1)
 	}
 }
+
+func configParserFromParam() {
+	var u URLTest
+	u.URL = config.OptURL
+	config.URLs = append(config.URLs, u)
+}

--- a/main.go
+++ b/main.go
@@ -1,32 +1,70 @@
-/* CLI startpoint - main package */
 package main
 
 import (
 	"flag"
 	"fmt"
+	"os"
 )
 
 /* Initialize */
 func init() {
 	/* Envs */
 	/* INPUT opts */
-	optConfig := flag.String("config", "./config.json", "Config filename.")
+	config.OptEmpty = true
+	optConfig := flag.String("config", "", "Config filename. Eg.: -default=hack/config.json")
+	optURL := flag.String("url", "", "URL to test.")
 	optDNS := flag.Bool("dns", false, "Force resolve DNS and test each endpoint.")
+	flag.Usage = usage
 	flag.Parse()
 
-	if optConfig != nil {
+	// -config is defined
+	if *optConfig != "" {
 		config.OptConfFile = *optConfig
+		config.OptEmpty = false
 	}
+
+	// -url has more precedence than -config
+	if *optURL != "" {
+		config.OptURL = *optURL
+
+		if config.OptConfFile != "" {
+			fmt.Println("\n WARNING: you cannot use -conifg and -url at same time.")
+			fmt.Println("\t Using -url option and ignoring -config parameter.")
+		}
+		config.OptEmpty = false
+	} else if len(flag.Args()) == 1 {
+		config.OptURL = flag.Arg(0)
+		config.OptEmpty = false
+	}
+
+	// extra options
 	if optDNS != nil {
 		config.OptForceDNS = *optDNS
 	}
 }
 
+func usage() {
+	fmt.Fprintf(os.Stderr, "usage: %s [-dns] (-config=inputfile|-url=url|url)\n", os.Args[0])
+	flag.PrintDefaults()
+	os.Exit(2)
+}
+
 /* Main tester function */
 func main() {
 
-	fmt.Printf("#> Reading config from JSON file: %s\n", config.OptConfFile)
-	configParserFromFile()
+	if (len(flag.Args()) < 1) && (config.OptEmpty) {
+		fmt.Println("#> missing arguments")
+		usage()
+		os.Exit(1)
+	}
+
+	if config.OptURL == "" {
+		fmt.Printf("#> Reading config from JSON file: %s\n", config.OptConfFile)
+		configParserFromFile()
+	} else {
+		fmt.Printf("#> Reading config from Param\n")
+		configParserFromParam()
+	}
 
 	/* Make the tests */
 	urlTestLauncher()

--- a/types.go
+++ b/types.go
@@ -11,6 +11,8 @@ type GlobalConfig struct {
 	WG          sync.WaitGroup
 	OptForceDNS bool
 	OptConfFile string
+	OptURL      string
+	OptEmpty    bool
 }
 
 // URLTest is a test definition


### PR DESCRIPTION
- introducing to `-url` param
```bash
$ ./bin/go-url -url https://www.google.com
#> Reading config from Param
#> Found [1] URLs to test, starting...
URL=[                            https://www.google.com] [  OK] : [200 OK] [952 ms]
Total time taken: 953ms

$ ./bin/go-url -url https://www.google.com -dns
#> Reading config from Param
#> Found [1] URLs to test, starting...

URL=[    (www.google.com) https://[2607:f8b0:4008:811::2004]:443/] [  OK] : [200 OK] [962 ms] [DNS 106 ms]
URL=[              (www.google.com)   https://172.217.29.132:443/] [  OK] : [200 OK] [377 ms] [DNS 106 ms]
Total time taken: 1446ms


```

- supporting `argv[1]` param as default target to test
```bash
$ ./bin/go-url https://www.google.com
#> Reading config from Param
#> Found [1] URLs to test, starting...
URL=[                            https://www.google.com] [  OK] : [200 OK] [942 ms]
Total time taken: 942ms

$ ./bin/go-url -dns https://www.google.com 
#> Reading config from Param
#> Found [1] URLs to test, starting...

URL=[    (www.google.com) https://[2607:f8b0:4008:811::2004]:443/] [  OK] : [200 OK] [1870 ms] [DNS 113 ms]
URL=[              (www.google.com)    https://172.217.30.68:443/] [  OK] : [200 OK] [236 ms] [DNS 113 ms]

```
