### PR TITLE
Supporting push metrics to Pushgateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ build:
 	$(call deps_dirs)
 	go build -o bin/go-url *.go
 
-run:
-	go run *.go -url=http://www.google.com
+run-sample:
+	go run *.go -dns -url=http://www.google.com
 
 clean:
 	$(call deps_clean)
@@ -48,6 +48,13 @@ release:
 # ######
 # Docker
 
+.PHONY: docker-run-sample
+docker-run-sample:
+	docker run -i \
+		-v $(PWD)/hack/config-sample.json:/config-sample.json \
+		"$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" \
+		-dns -config /config-sample.json
+
 .PHONY: docker-build
 docker-build:
 	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
@@ -58,4 +65,13 @@ docker-push:
 
 .PHONY: docker-tag-latest
 docker-tag-latest:
-	docker tag "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):latest"
+	docker tag \
+		"$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"
+		"$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):latest"
+
+# ####
+# Test
+
+.PHONY: test-run-metrics-stack
+test-run-metrics-stack:
+	cd hack && docker-compose up -d

--- a/config.go
+++ b/config.go
@@ -25,10 +25,21 @@ func configParserFromFile() {
 		fmt.Println("error:", err)
 		os.Exit(1)
 	}
+	assertConfig()
 }
 
 func configParserFromParam() {
 	var u URLTest
 	u.URL = config.OptURL
 	config.URLs = append(config.URLs, u)
+	assertConfig()
+}
+
+func assertConfig() {
+	if config.Location == "" {
+		config.Location = os.Getenv("HOSTNAME")
+	}
+	if config.MetricPush == "" {
+		config.MetricPush = "http://localhost:9091"
+	}
 }

--- a/hack/config-sample.json
+++ b/hack/config-sample.json
@@ -1,4 +1,6 @@
 {
+  "location": "us-east1-aws",
+  "metric_push": "http://localhost:9091",
   "urls":
   [
     {

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.3'
+
+services:
+   pushgateway:
+     image: prom/pushgateway
+     ports:
+       - "9091:9091"
+     restart: always
+   prometheus:
+     image: prom/prometheus
+     volumes:
+       - ./prometheus.yml:/prometheus.yml
+     ports:
+       - "9090:9090"
+     restart: always
+     command:
+      - --config.file=/prometheus.yml
+

--- a/hack/prometheus.yml
+++ b/hack/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval:     30s # default: 15s
+  evaluation_interval: 30s # default: 15s
+  scrape_timeout:      5s  # default: 10s
+
+scrape_configs:
+  - job_name: 'pushgateway'
+    scrape_interval: 10s
+    honor_labels: true
+
+    static_configs:
+      - targets:
+        - 'pushgateway:9091'
+
+

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/push"
+)
+
+func sendMetrics(metrics []Metric) {
+	metricLocation := config.Location
+
+	metricHTTPTime := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "gourl_test_http_time_ms",
+		Help: "GoURL test - HTTP Time Taken milliseconds.",
+	})
+	metricDNSTime := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "gourl_test_dns_time_ms",
+		Help: "GoURL test - DNS Time Taken milliseconds.",
+	})
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(metricHTTPTime, metricDNSTime)
+
+	for _, m := range metrics {
+		pusher := push.New(config.MetricPush, "gourl").
+			Grouping("location", metricLocation).
+			Gatherer(registry)
+		pusher.Grouping("server", m.HTTPServer)
+		pusher.Grouping("host", m.HTTPHost)
+		metricHTTPTime.Add(float64(m.HTTPTimeTaken))
+
+		if m.DNSTimeTaken != 0 {
+			metricDNSTime.Add(float64(m.DNSTimeTaken))
+		}
+		pusher.Push()
+	}
+}

--- a/types.go
+++ b/types.go
@@ -7,6 +7,8 @@ import (
 // GlobalConfig is a main list of tests to go
 type GlobalConfig struct {
 	URLs        []URLTest `json:"urls"`
+	Location    string    `json:"location"`
+	MetricPush  string    `json:"metric_push"`
 	ChanResp    chan URLTestResult
 	WG          sync.WaitGroup
 	OptForceDNS bool
@@ -38,7 +40,18 @@ type URLTestGroup struct {
 
 // URLTestResult is a result struct for the tests
 type URLTestResult struct {
-	Message string
-	Status  string
-	Body    string
+	Message      string
+	Status       string
+	Body         string
+	DNSTimeTaken int64
+	Metrics      []Metric
+}
+
+// Metric is a results
+type Metric struct {
+	HTTPCode      string
+	HTTPTimeTaken int64
+	HTTPHost      string
+	HTTPServer    string
+	DNSTimeTaken  int64
 }


### PR DESCRIPTION
- supporting send metrics to pushgateway endpoint
- add docker metric stack (prometheus + pushgateway) on docker-compose to local test
- creating test location label to identify different src test locations to identify each test in metrics