### PR TITLE
fix/validation-url: add Raw path when it's not defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 	go build -o bin/go-url *.go
 
 run-sample:
-	go run *.go -dns -url=http://www.google.com
+	go run *.go -dns -url='https://www.google.com/search?source=hp&q=google'
 
 clean:
 	$(call deps_clean)

--- a/url-test.go
+++ b/url-test.go
@@ -88,6 +88,9 @@ func urlValidate(u *URLTest) {
 		} else {
 			u.Path = parsedURL.Path
 		}
+		if parsedURL.RawQuery != "" {
+			u.Path += "?" + parsedURL.RawQuery
+		}
 	}
 }
 


### PR DESCRIPTION
Full path is not append to the request when DNS resolver is true:

* Error request

```bash
$ go run *.go -dns -url='https://www.google.com/search?source=hp&q=google'
#> Reading config from Param
#> Found [1] URLs to test, starting...

URL=[(www.google.com) https://[2607:f8b0:4004:805::2004]:443/search] [FAIL] : 
	 Get https://[2607:f8b0:4004:805::2004]:443/search: dial tcp [2607:f8b0:4004:805::2004]:443: connect: network is unreachable [DNS 151 ms]
URL=[         (www.google.com) https://172.217.164.164:443/search] [  OK] : [200 OK] [1501 ms] [DNS 151 ms]
Total time taken: 1654ms
```

* fixes

```bash
$ go run *.go -dns -url='https://www.google.com/search?source=hp&q=google'
#> Reading config from Param
#> Found [1] URLs to test, starting...

URL=[(www.google.com) https://[2607:f8b0:4004:811::2004]:443/search?source=hp&q=google] [FAIL] : 
	 Get https://[2607:f8b0:4004:811::2004]:443/search?source=hp&q=google: dial tcp [2607:f8b0:4004:811::2004]:443: connect: network is unreachable [DNS 147 ms]
URL=[(www.google.com) https://172.217.8.4:443/search?source=hp&q=google] [  OK] : [200 OK] [871 ms] [DNS 147 ms]
Total time taken: 1019ms

```
