### PR TITLE
feat/watch: add watcher option. #14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ include Makefile-defines.mk
 # #####
 # Build
 build:
-	go build -o bin/go-url *.go
+	go build -o bin/go-url cmd/go-url/*.go
 
 run-sample:
-	go run *.go -dns -url='https://www.google.com/search?source=hp&q=google'
+	go run cmd/go-url/*.go -dns -url='https://www.google.com/search?source=hp&q=google'
 
 clean:
 	$(call deps_clean)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Read url from option `-url`
 
 ***[sample stdout](./samples-stdout.md#Option--url)***
 
+### `-watch-*`
+
+Add a option to watch requests (repeat requests):
+
+```bash
+go-url -dns -watch-period 20 -watch-interval 2 https://www.google.com
+```
+
 ### Argument
 
 Read url from argument (`argv[1]`)

--- a/cmd/go-url/main.go
+++ b/cmd/go-url/main.go
@@ -15,6 +15,9 @@ func init() {
 	optURL := flag.String("url", "", "URL to test.")
 	optDNS := flag.Bool("dns", false, "Force resolve DNS and test each endpoint.")
 	optMetric := flag.String("metric", "", "Report metrics to pushgateway endpoint.")
+	optWPeriod := flag.Int("watch-period", 0, "Watch period in seconds. Default: 0 (Disabled)")
+	optWInterval := flag.Int("watch-interval", 5, "Interval in seconds to watch. Should be less than the period. Default: 5")
+
 	flag.Usage = usage
 	flag.Parse()
 
@@ -46,6 +49,11 @@ func init() {
 	if *optMetric != "" {
 		config.OptMetric = true
 		config.MetricPush = *optMetric
+	}
+
+	if *optWPeriod != 0 {
+		config.WatchPeriod = *optWPeriod
+		config.WatchInterval = *optWInterval
 	}
 }
 

--- a/cmd/go-url/types.go
+++ b/cmd/go-url/types.go
@@ -6,16 +6,18 @@ import (
 
 // GlobalConfig is a main list of tests to go
 type GlobalConfig struct {
-	URLs        []URLTest `json:"urls"`
-	Location    string    `json:"location"`
-	MetricPush  string    `json:"metric_push"`
-	ChanResp    chan URLTestResult
-	WG          sync.WaitGroup
-	OptForceDNS bool
-	OptConfFile string
-	OptURL      string
-	OptEmpty    bool
-	OptMetric   bool
+	URLs          []URLTest `json:"urls"`
+	Location      string    `json:"location"`
+	MetricPush    string    `json:"metric_push"`
+	ChanResp      chan URLTestResult
+	WG            sync.WaitGroup
+	OptForceDNS   bool
+	OptConfFile   string
+	OptURL        string
+	OptEmpty      bool
+	OptMetric     bool
+	WatchPeriod   int
+	WatchInterval int
 }
 
 // URLTest is a test definition


### PR DESCRIPTION
Self described, repeat requests every period. Default is disabled.

```bash
go run cmd/go-url/*.go -dns -watch-period 20 -watch-interval 2 'https://multicluster-test-s2rs4-ext-bdc4371d715efc34.elb.us-east-1.amazonaws.com:6443/readyz'
#> Reading config from Param
#> Found [1] URLs to test, starting...

URL=[(multicluster-test-s2rs4-ext-bd) https://54.166.101.111:6443/readyz] [  OK] : [200 OK] [681 ms] [DNS 40 ms]
URL=[(multicluster-test-s2rs4-ext-bd) https://44.197.225.14:6443/readyz] [  OK] : [200 OK] [681 ms] [DNS 40 ms]
URL=[(multicluster-test-s2rs4-ext-bd) https://3.216.58.210:6443/readyz] [  OK] : [200 OK] [681 ms] [DNS 40 ms]
URL=[(multicluster-test-s2rs4-ext-bd) https://34.232.122.66:6443/readyz] [  OK] : [200 OK] [681 ms] [DNS 40 ms]
URL=[(multicluster-test-s2rs4-ext-bd) https://34.206.195.101:6443/readyz] [  OK] : [200 OK] [681 ms] [DNS 40 ms]
Total time taken: 722ms
Watcher waiting 2s, of period 20s

```

issue ref https://github.com/mtulio/go-url/issues/14